### PR TITLE
Refactor GPIO and remove mutex

### DIFF
--- a/src/ESP_FlexyStepper.h
+++ b/src/ESP_FlexyStepper.h
@@ -47,7 +47,7 @@
 #include <Arduino.h>
 #include <stdlib.h>
 #include <freertos/FreeRTOS.h>
-#include <freertos/semphr.h>
+#include <driver/gpio.h>
 
 typedef void (*callbackFunction)(void);
 typedef void (*positionCallbackFunction)(long);
@@ -245,9 +245,6 @@ private:
   long _homingMaxDistance = 0;
   int _homingSwitchPin = -1;
   signed char _homingDirection = 0;
-
-  // protección de variables compartidas
-  SemaphoreHandle_t _stateMutex;
 
   // soporte para movimiento continuo
   bool _continuousMovement = false;


### PR DESCRIPTION
## Summary
- Replace digitalWrite usage with direct gpio_set_level calls and configure pins via gpio_set_direction
- Remove FreeRTOS mutex and rely on lock-free access to state variables
- Raise stepper service task priority to improve timing

## Testing
- `g++ -c src/ESP_FlexyStepper.cpp -Isrc` *(fails: Platform not supported, only ESP32 modules are currently supported)*

------
https://chatgpt.com/codex/tasks/task_e_6892c39eaa888321bb4c25c5a3491ce3